### PR TITLE
fix: surface Trinnov command convergence failures

### DIFF
--- a/custom_components/trinnov_altitude/commands.py
+++ b/custom_components/trinnov_altitude/commands.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.exceptions import HomeAssistantError
+
 from trinnov_altitude.client import TrinnovAltitudeClient
+from trinnov_altitude.exceptions import NotConnectedError, TrinnovAltitudeError
 from trinnov_altitude.lifecycle import PowerState
 
 
@@ -26,35 +29,42 @@ class TrinnovAltitudeCommands:
         self, method_name: str, *args: Any, require_ack: bool = False
     ) -> None:
         """Invoke a client command by method name, with optional ACK wait."""
-        if method_name == "source_set_by_name":
-            if len(args) != 1:
-                raise ValueError("source_set_by_name expects exactly one source name")
-            source_name = str(args[0])
-            for source_id, name in self._client.state.sources.items():
-                if name == source_name:
-                    await self._client.source_set(source_id)
-                    return
-            raise ValueError(f"Unknown source name: {source_name}")
-
-        if method_name in self._CLIENT_CONVERGENCE_METHODS:
-            await getattr(self._client, method_name)(*args)
-            return
-
-        if require_ack:
-            line = self._build_line(method_name, args)
-            if line is not None:
-                await self._client.command(
-                    line,
-                    wait_for_ack=True,
-                    ack_timeout=self._client.command_timeout,
-                )
-                if method_name == "power_off":
-                    self._client.runtime = self._client.runtime.with_changes(
-                        power=PowerState.OFF
+        try:
+            if method_name == "source_set_by_name":
+                if len(args) != 1:
+                    raise ValueError(
+                        "source_set_by_name expects exactly one source name"
                     )
+                source_name = str(args[0])
+                for source_id, name in self._client.state.sources.items():
+                    if name == source_name:
+                        await self._client.source_set(source_id)
+                        return
+                raise ValueError(f"Unknown source name: {source_name}")
+
+            if method_name in self._CLIENT_CONVERGENCE_METHODS:
+                await getattr(self._client, method_name)(*args)
                 return
 
-        await getattr(self._client, method_name)(*args)
+            if require_ack:
+                line = self._build_line(method_name, args)
+                if line is not None:
+                    await self._client.command(
+                        line,
+                        wait_for_ack=True,
+                        ack_timeout=self._client.command_timeout,
+                    )
+                    if method_name == "power_off":
+                        self._client.runtime = self._client.runtime.with_changes(
+                            power=PowerState.OFF
+                        )
+                    return
+
+            await getattr(self._client, method_name)(*args)
+        except NotConnectedError:
+            raise
+        except TrinnovAltitudeError as exc:
+            raise HomeAssistantError(str(exc)) from exc
 
     def _build_line(self, method_name: str, args: tuple[Any, ...]) -> str | None:
         """Build raw protocol line for known methods."""

--- a/custom_components/trinnov_altitude/manifest.json
+++ b/custom_components/trinnov_altitude/manifest.json
@@ -12,7 +12,7 @@
     "trinnov_altitude"
   ],
   "requirements": [
-    "trinnov-altitude>=3.3.2"
+    "trinnov-altitude>=3.3.3"
   ],
   "version": "2.2.1"
 }

--- a/custom_components/trinnov_altitude/sensor.py
+++ b/custom_components/trinnov_altitude/sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -33,12 +33,14 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
     from homeassistant.helpers.typing import StateType
 
+    from trinnov_altitude.adapter import AltitudeSnapshot
+
 
 @dataclass(frozen=True, kw_only=True)
 class TrinnovAltitudeSensorEntityDescription(SensorEntityDescription):
     """Describes Trinnov Altitude sensor entity."""
 
-    value_fn: Callable[[object], StateType]
+    value_fn: Callable[[AltitudeSnapshot], StateType]
 
 
 POWER_STATUS_ICONS = {
@@ -206,7 +208,5 @@ class TrinnovAltitudeSensor(TrinnovAltitudeEntity, SensorEntity):
     def icon(self) -> str | None:
         """Return dynamic icon for power_status sensor."""
         if self.entity_description.key == "power_status":
-            return POWER_STATUS_ICONS.get(
-                cast(PowerState, self.coordinator.power_status)
-            )
+            return POWER_STATUS_ICONS.get(self.coordinator.power_status)
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.7"
 description = "Home Assistant integration for Trinnov Altitude"
 requires-python = ">=3.11"
 dependencies = [
-    "trinnov-altitude>=3.3.2",
+    "trinnov-altitude>=3.3.3",
 ]
 
 [dependency-groups]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 from trinnov_altitude.const import RemappingMode
+from trinnov_altitude.exceptions import CommandConvergenceTimeoutError
 
 from custom_components.trinnov_altitude.commands import TrinnovAltitudeCommands
 
@@ -63,6 +65,18 @@ async def test_invoke_with_ack_for_source_set_by_name() -> None:
 
     client.source_set.assert_called_once_with(1)
     client.command.assert_not_called()
+
+
+async def test_invoke_wraps_protocol_command_errors() -> None:
+    """Protocol command failures should surface as Home Assistant errors."""
+    client = _mock_client()
+    client.source_set.side_effect = CommandConvergenceTimeoutError(
+        "source 0 to become active", 5.0
+    )
+    commands = TrinnovAltitudeCommands(client)
+
+    with pytest.raises(HomeAssistantError, match="source 0"):
+        await commands.invoke("source_set", 0, require_ack=True)
 
 
 async def test_invoke_with_ack_for_remapping_mode_set() -> None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,8 +1,11 @@
 """Test the Trinnov Altitude number platform."""
 
+import pytest
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from trinnov_altitude.exceptions import CommandConvergenceTimeoutError
 
 
 async def test_volume_number(hass: HomeAssistant, mock_config_entry, mock_setup_entry):
@@ -45,6 +48,32 @@ async def test_volume_number_set_value(
 
     # Verify device method was called
     mock_device.volume_set.assert_called_once_with(-35.5)
+
+
+async def test_volume_number_set_value_surfaces_command_error(
+    hass: HomeAssistant, mock_config_entry, mock_setup_entry
+):
+    """Test volume convergence failures surface as Home Assistant errors."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_device = mock_setup_entry.return_value
+    mock_device.volume_set.side_effect = CommandConvergenceTimeoutError(
+        "volume -15.0 dB to be active", 5.0
+    )
+
+    with pytest.raises(HomeAssistantError, match="volume -15.0"):
+        await hass.services.async_call(
+            "number",
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.trinnov_altitude_192_168_1_100_volume",
+                ATTR_VALUE: -15.0,
+            },
+            blocking=True,
+        )
 
 
 async def test_volume_number_updates(


### PR DESCRIPTION
## Summary
- require trinnov-altitude >= 3.3.3
- surface protocol command convergence failures as Home Assistant errors
- preserve the existing remote not-connected message

## Tests
- make check