### PR TITLE
[codex] require safe preset convergence library

### DIFF
--- a/custom_components/trinnov_altitude/manifest.json
+++ b/custom_components/trinnov_altitude/manifest.json
@@ -12,7 +12,7 @@
     "trinnov_altitude"
   ],
   "requirements": [
-    "trinnov-altitude>=3.3.3"
+    "trinnov-altitude>=3.3.4"
   ],
   "version": "2.2.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.7"
 description = "Home Assistant integration for Trinnov Altitude"
 requires-python = ">=3.11"
 dependencies = [
-    "trinnov-altitude>=3.3.3",
+    "trinnov-altitude>=3.3.4",
 ]
 
 [dependency-groups]

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,12 +1,17 @@
 """Test the Trinnov Altitude select platform."""
 
+from unittest.mock import patch
+
 import pytest
 from homeassistant.components.select import ATTR_OPTION, SERVICE_SELECT_OPTION
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from trinnov_altitude.client import TrinnovAltitudeClient
+from trinnov_altitude.mocks import MockTrinnovAltitudeServer
 
-from custom_components.trinnov_altitude.const import DOMAIN
+from custom_components.trinnov_altitude.const import CLIENT_ID, DOMAIN
 from custom_components.trinnov_altitude.select import (
     TrinnovAltitudePresetSelect,
     TrinnovAltitudeSourceSelect,
@@ -146,6 +151,70 @@ async def test_preset_select_option(
     )
 
     mock_device.preset_set.assert_called_once_with(2)
+
+
+async def test_preset_select_uses_safe_library_wire_flow(
+    hass: HomeAssistant, socket_enabled
+):
+    """Preset select should send one load command and converge with readback."""
+    server = MockTrinnovAltitudeServer(
+        host="127.0.0.1",
+        port=0,
+        presets={0: "Built-in", 1: "Movies", 2: "Music"},
+        current_preset_index=1,
+        preset_readback_lag=2,
+    )
+    await server.start_server()
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Trinnov Altitude (127.0.0.1)",
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_MAC: "00:11:22:33:44:55",
+            CLIENT_ID: "test_client",
+        },
+        unique_id="ABC123",
+    )
+
+    def client_factory(host: str, mac: str | None, client_id: str):
+        return TrinnovAltitudeClient(
+            host=host,
+            port=server.port,
+            mac=mac,
+            client_id=client_id,
+            auto_reconnect=False,
+            connect_timeout=1.0,
+            command_timeout=1.0,
+            read_timeout=0.1,
+            selector_convergence_timeout=1.0,
+            selector_convergence_interval=0.0,
+        )
+
+    try:
+        with patch(
+            "custom_components.trinnov_altitude.TrinnovAltitudeClient",
+            side_effect=client_factory,
+        ):
+            config_entry.add_to_hass(hass)
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            await hass.services.async_call(
+                "select",
+                SERVICE_SELECT_OPTION,
+                {
+                    ATTR_ENTITY_ID: "select.trinnov_altitude_127_0_0_1_preset",
+                    ATTR_OPTION: "Music",
+                },
+                blocking=True,
+            )
+
+            assert server.received_messages.count("loadp 2") == 1
+            assert server.received_messages.count("get_current_preset") >= 3
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await server.stop_server()
 
 
 async def test_select_updates(hass: HomeAssistant, mock_config_entry, mock_setup_entry):

--- a/uv.lock
+++ b/uv.lock
@@ -6602,7 +6602,6 @@ resolution-markers = [
 dependencies = [
     { name = "pytest", version = "9.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2' and python_full_version < '3.14.2'" },
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
-    { name = "typing-extensions", marker = "python_version < '0'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
@@ -8320,14 +8319,14 @@ wheels = [
 
 [[package]]
 name = "trinnov-altitude"
-version = "3.3.3"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wakeonlan" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/e7/9516b686cecc085fcb6ba9bbc1b0be7b30954f03745acb5d91e44375721d/trinnov_altitude-3.3.3.tar.gz", hash = "sha256:65ba4d01639639c80b1570226ee839986f4d697611609a967c896ea1b4209459", size = 242316, upload-time = "2026-06-15T23:37:01.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/28/079b71fb5b6ec780a32e512b58044675bb41676c2072accfd69508d18c4b/trinnov_altitude-3.3.4.tar.gz", hash = "sha256:63981aa1a4adc42fc3b31b47f92834d68ee95ef9dfa71df98b68f83b68794a7d", size = 253879, upload-time = "2026-06-17T19:00:44.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/5a/dac29e4b4e61a2d9ec84e2bf001fa2ed85461c8d4705845344a4eb285ea1/trinnov_altitude-3.3.3-py3-none-any.whl", hash = "sha256:ca5a6e19af98ff70d88ca56e28ef2aeaa3d65e3c5551f95c7e5822631ee3df54", size = 28839, upload-time = "2026-06-15T23:36:59.632Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/6d3b8f6fd6d4bd205b4a55193d302fba4bfdfffa4abe03bbf4442a904875/trinnov_altitude-3.3.4-py3-none-any.whl", hash = "sha256:96ddd2726bc77b4028c79c207229b089acfc2de546d8823b7bf5899c64928a73", size = 29582, upload-time = "2026-06-17T19:00:43.605Z" },
 ]
 
 [[package]]
@@ -8363,7 +8362,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.3" }]
+requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- require `trinnov-altitude>=3.3.4`, which fixes preset convergence by sending `loadp` once and polling readback
- update `uv.lock` to the published 3.3.4 package
- add an HA select integration regression that uses the real library client against the local TCP simulator and verifies preset selection sends exactly one `loadp`

## Root Cause

`trinnov-altitude` v3.3.3 could repeat `loadp <id>` while waiting for preset readback to converge. Preset loads are not safe to retry aggressively. The fixed library release, v3.3.4, sends the mutating preset command once and repeats only `get_current_preset` readback.

## Validation

- `make lint`
- `make format-check`
- `make typecheck`
- `make test`
