### PR TITLE
fix: use db volume flow

### DIFF
--- a/custom_components/trinnov_altitude/manifest.json
+++ b/custom_components/trinnov_altitude/manifest.json
@@ -12,7 +12,7 @@
     "trinnov_altitude"
   ],
   "requirements": [
-    "trinnov-altitude>=3.3.4"
+    "trinnov-altitude>=3.3.5"
   ],
   "version": "2.2.3"
 }

--- a/custom_components/trinnov_altitude/media_player.py
+++ b/custom_components/trinnov_altitude/media_player.py
@@ -47,7 +47,6 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.VOLUME_MUTE
-        | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
     )
 
@@ -88,11 +87,6 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
         """Turn volume down for media player."""
         await self._commands.invoke("volume_down")
 
-    async def async_set_volume_level(self, volume: float) -> None:
-        """Set volume level, range 0..1."""
-        percentage = volume * 100.0
-        await self._commands.invoke("volume_percentage_set", percentage)
-
     @property
     def available(self) -> bool:
         """Return if device is available."""
@@ -124,12 +118,3 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
         if self._state.source_format:
             return MediaPlayerState.PLAYING
         return MediaPlayerState.IDLE
-
-    @property
-    def volume_level(self) -> float | None:
-        """Volume level of the media player (0..1)."""
-        percentage = self._client.volume_percentage
-        if percentage is None:
-            return None
-        else:
-            return percentage / 100.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.7"
 description = "Home Assistant integration for Trinnov Altitude"
 requires-python = ">=3.11"
 dependencies = [
-    "trinnov-altitude>=3.3.4",
+    "trinnov-altitude>=3.3.5",
 ]
 
 [dependency-groups]

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -5,14 +5,12 @@ import logging
 import pytest
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
-    ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
     SERVICE_SELECT_SOURCE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     SERVICE_VOLUME_DOWN,
     SERVICE_VOLUME_MUTE,
-    SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
     MediaPlayerState,
 )
@@ -37,7 +35,7 @@ async def test_media_player(hass: HomeAssistant, mock_config_entry, mock_setup_e
     assert state
     assert state.state == MediaPlayerState.PLAYING
     assert state.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is False
-    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) == 0.5
+    assert "volume_level" not in state.attributes
 
     data = hass.data[DOMAIN][mock_config_entry.entry_id]
     entity = TrinnovAltitudeMediaPlayer(data.coordinator)
@@ -140,23 +138,6 @@ async def test_media_player_select_source_invalid_name_raises_ha_error(
             },
             blocking=True,
         )
-
-
-async def test_media_player_volume_level_none_when_percentage_missing(
-    hass: HomeAssistant, mock_config_entry, mock_setup_entry
-):
-    """Volume level should be None when the device has no percentage reading."""
-    mock_device = mock_setup_entry.return_value
-    mock_device.volume_percentage = None
-
-    mock_config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("media_player.trinnov_altitude_192_168_1_100")
-    assert state
-    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) is None
 
 
 async def test_media_player_unavailable_when_not_connected_and_no_wake_path(
@@ -284,32 +265,6 @@ async def test_media_player_volume_down(
     )
 
     mock_device.volume_down.assert_called_once()
-
-
-async def test_media_player_set_volume(
-    hass: HomeAssistant, mock_config_entry, mock_setup_entry
-):
-    """Test setting volume level."""
-    mock_config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    mock_device = mock_setup_entry.return_value
-
-    # Set volume to 75% (0.75)
-    await hass.services.async_call(
-        "media_player",
-        SERVICE_VOLUME_SET,
-        {
-            ATTR_ENTITY_ID: "media_player.trinnov_altitude_192_168_1_100",
-            ATTR_MEDIA_VOLUME_LEVEL: 0.75,
-        },
-        blocking=True,
-    )
-
-    # Should convert to percentage
-    mock_device.volume_percentage_set.assert_called_once_with(75.0)
 
 
 async def test_media_player_mute(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,11 +1,20 @@
 """Test the Trinnov Altitude number platform."""
 
+import asyncio
+import contextlib
+from unittest.mock import patch
+
 import pytest
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from trinnov_altitude.client import TrinnovAltitudeClient
 from trinnov_altitude.exceptions import CommandConvergenceTimeoutError
+from trinnov_altitude.mocks import MockTrinnovAltitudeServer
+
+from custom_components.trinnov_altitude.const import CLIENT_ID, DOMAIN
 
 
 async def test_volume_number(hass: HomeAssistant, mock_config_entry, mock_setup_entry):
@@ -48,6 +57,66 @@ async def test_volume_number_set_value(
 
     # Verify device method was called
     mock_device.volume_set.assert_called_once_with(-35.5)
+
+
+async def test_volume_number_uses_db_wire_flow(hass: HomeAssistant, socket_enabled):
+    """Volume number should send absolute dB once and request volume readback."""
+    server = MockTrinnovAltitudeServer(host="127.0.0.1", port=0)
+    server.volume = -22.0
+    await server.start_server()
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Trinnov Altitude (127.0.0.1)",
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_MAC: "00:11:22:33:44:55",
+            CLIENT_ID: "test_client",
+        },
+        unique_id="ABC123",
+    )
+
+    def client_factory(host: str, mac: str | None, client_id: str):
+        return TrinnovAltitudeClient(
+            host=host,
+            port=server.port,
+            mac=mac,
+            client_id=client_id,
+            auto_reconnect=False,
+            connect_timeout=1.0,
+            command_timeout=1.0,
+            read_timeout=0.1,
+        )
+
+    try:
+        with patch(
+            "custom_components.trinnov_altitude.TrinnovAltitudeClient",
+            side_effect=client_factory,
+        ):
+            config_entry.add_to_hass(hass)
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+            await hass.services.async_call(
+                "number",
+                SERVICE_SET_VALUE,
+                {
+                    ATTR_ENTITY_ID: "number.trinnov_altitude_127_0_0_1_volume",
+                    ATTR_VALUE: -17.5,
+                },
+                blocking=True,
+            )
+
+            await asyncio.wait_for(
+                _wait_for(lambda: server.received_messages.count("send volume") == 1),
+                timeout=1.0,
+            )
+
+            assert server.received_messages.count("volume -17.5") == 1
+            assert server.received_messages.count("send volume") == 1
+    finally:
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await server.stop_server()
 
 
 async def test_volume_number_set_value_surfaces_command_error(
@@ -163,3 +232,13 @@ async def test_volume_number_min_max_bounds(
     )
 
     mock_device.volume_set.assert_called_with(0.0)
+
+
+async def _wait_for(predicate):
+    if predicate():
+        return
+
+    event = asyncio.Event()
+    while not predicate():
+        with contextlib.suppress(asyncio.TimeoutError, TimeoutError):
+            await asyncio.wait_for(event.wait(), timeout=0.01)

--- a/uv.lock
+++ b/uv.lock
@@ -8319,14 +8319,14 @@ wheels = [
 
 [[package]]
 name = "trinnov-altitude"
-version = "3.3.4"
+version = "3.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wakeonlan" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/28/079b71fb5b6ec780a32e512b58044675bb41676c2072accfd69508d18c4b/trinnov_altitude-3.3.4.tar.gz", hash = "sha256:63981aa1a4adc42fc3b31b47f92834d68ee95ef9dfa71df98b68f83b68794a7d", size = 253879, upload-time = "2026-06-17T19:00:44.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/2c/302010338aca3f1383b35a94277b3b3ccf311925c49f1c80aad761373cfa/trinnov_altitude-3.3.5.tar.gz", hash = "sha256:3db790e88df6d4bb0753787d5bbee258e8cef8319dfd434eeffeabc880af93c9", size = 253979, upload-time = "2026-06-18T06:05:49.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/9b/6d3b8f6fd6d4bd205b4a55193d302fba4bfdfffa4abe03bbf4442a904875/trinnov_altitude-3.3.4-py3-none-any.whl", hash = "sha256:96ddd2726bc77b4028c79c207229b089acfc2de546d8823b7bf5899c64928a73", size = 29582, upload-time = "2026-06-17T19:00:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9a/5f4972c9adff60653c5431e2961fcf86d9a039fb71d91265dc5e4b05c846/trinnov_altitude-3.3.5-py3-none-any.whl", hash = "sha256:151f16d2e87827a28d5a177be0b8a207d4f3498912d00c4ee103985a541e4f39", size = 29569, upload-time = "2026-06-18T06:05:48.61Z" },
 ]
 
 [[package]]
@@ -8362,7 +8362,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.4" }]
+requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.5" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- require `trinnov-altitude>=3.3.5` for the simplified absolute dB volume command flow
- stop exposing Home Assistant `media_player.volume_set`, which is normalized 0..1 and does not represent Trinnov dB volume
- keep volume changes on the dB-backed number entity and volume step services, with an integration test against the TCP simulator

## Root cause
Home Assistant `media_player.volume_set` is percentage based, but Trinnov volume is absolute dB. Sending a normalized slider value converted a useful dB target like `17.5` into a tiny percentage-derived volume. The library also retried absolute volume commands while polling full state, which could make rapid volume changes janky and produce command-send failures.

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `make test`

Library dependency `trinnov-altitude 3.3.5` was released first and verified on PyPI.