### PR TITLE
fix: project media player volume from db

### DIFF
--- a/custom_components/trinnov_altitude/media_player.py
+++ b/custom_components/trinnov_altitude/media_player.py
@@ -18,6 +18,7 @@ from trinnov_altitude.lifecycle import PowerState
 from .const import DOMAIN
 from .entity import TrinnovAltitudeEntity
 from .models import TrinnovAltitudeIntegrationData
+from .volume import db_to_level, level_to_db
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -47,6 +48,7 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_ON
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
     )
 
@@ -87,6 +89,10 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
         """Turn volume down for media player."""
         await self._commands.invoke("volume_down")
 
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level, range 0..1."""
+        await self._commands.invoke("volume_set", level_to_db(volume))
+
     @property
     def available(self) -> bool:
         """Return if device is available."""
@@ -106,6 +112,13 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
     def is_volume_muted(self) -> bool | None:
         """Boolean if volume is currently muted."""
         return self._state.mute
+
+    @property
+    def volume_level(self) -> float | None:
+        """Volume level of the media player, range 0..1."""
+        if self._state.volume is None:
+            return None
+        return db_to_level(self._state.volume)
 
     @property
     def state(self) -> MediaPlayerState:

--- a/custom_components/trinnov_altitude/number.py
+++ b/custom_components/trinnov_altitude/number.py
@@ -11,16 +11,12 @@ from .const import DOMAIN
 from .coordinator import TrinnovAltitudeCoordinator
 from .entity import TrinnovAltitudeEntity
 from .models import TrinnovAltitudeIntegrationData
+from .volume import VOLUME_MAX_DB, VOLUME_MIN_DB
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-# Volume range: -120 dB to 0 dB (capped at 0 for safety)
-# Reference level (0 dB) is very loud. Values above 0 dB can damage speakers/hearing.
-VOLUME_MIN = -120.0
-VOLUME_MAX = 0.0
 
 
 async def async_setup_entry(
@@ -34,8 +30,8 @@ async def async_setup_entry(
 class TrinnovAltitudeVolumeNumber(TrinnovAltitudeEntity, NumberEntity):
     """Representation of a Trinnov Altitude volume number entity."""
 
-    _attr_native_min_value = VOLUME_MIN
-    _attr_native_max_value = VOLUME_MAX
+    _attr_native_min_value = VOLUME_MIN_DB
+    _attr_native_max_value = VOLUME_MAX_DB
     _attr_native_step = 0.5
     _attr_mode = NumberMode.SLIDER
     _attr_native_unit_of_measurement = UnitOfSoundPressure.DECIBEL

--- a/custom_components/trinnov_altitude/volume.py
+++ b/custom_components/trinnov_altitude/volume.py
@@ -1,0 +1,17 @@
+"""Volume projection helpers for Trinnov Altitude."""
+
+VOLUME_MIN_DB = -120.0
+VOLUME_MAX_DB = 0.0
+
+
+def db_to_level(db: float) -> float:
+    """Convert Trinnov dB volume to Home Assistant's 0..1 volume level."""
+    clamped = min(max(db, VOLUME_MIN_DB), VOLUME_MAX_DB)
+    return (clamped - VOLUME_MIN_DB) / (VOLUME_MAX_DB - VOLUME_MIN_DB)
+
+
+def level_to_db(level: float) -> float:
+    """Convert Home Assistant's 0..1 volume level to Trinnov dB volume."""
+    if not 0 <= level <= 1:
+        raise ValueError("Volume level must be between 0 and 1")
+    return round((level * (VOLUME_MAX_DB - VOLUME_MIN_DB)) + VOLUME_MIN_DB, 1)

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -5,12 +5,14 @@ import logging
 import pytest
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
     SERVICE_SELECT_SOURCE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     SERVICE_VOLUME_DOWN,
     SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
     MediaPlayerState,
 )
@@ -35,7 +37,7 @@ async def test_media_player(hass: HomeAssistant, mock_config_entry, mock_setup_e
     assert state
     assert state.state == MediaPlayerState.PLAYING
     assert state.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is False
-    assert "volume_level" not in state.attributes
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) == pytest.approx(2 / 3)
 
     data = hass.data[DOMAIN][mock_config_entry.entry_id]
     entity = TrinnovAltitudeMediaPlayer(data.coordinator)
@@ -265,6 +267,47 @@ async def test_media_player_volume_down(
     )
 
     mock_device.volume_down.assert_called_once()
+
+
+async def test_media_player_set_volume_maps_ha_level_to_db(
+    hass: HomeAssistant, mock_config_entry, mock_setup_entry
+):
+    """Test setting media player volume maps HA level to Trinnov dB."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_device = mock_setup_entry.return_value
+
+    await hass.services.async_call(
+        "media_player",
+        SERVICE_VOLUME_SET,
+        {
+            ATTR_ENTITY_ID: "media_player.trinnov_altitude_192_168_1_100",
+            ATTR_MEDIA_VOLUME_LEVEL: 0.8541666667,
+        },
+        blocking=True,
+    )
+
+    mock_device.volume_set.assert_called_once_with(-17.5)
+
+
+async def test_media_player_volume_level_none_when_db_missing(
+    hass: HomeAssistant, mock_config_entry, mock_setup_entry
+):
+    """Volume level should be None when the device has no dB reading."""
+    mock_device = mock_setup_entry.return_value
+    mock_device.state.volume = None
+
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.trinnov_altitude_192_168_1_100")
+    assert state
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) is None
 
 
 async def test_media_player_mute(


### PR DESCRIPTION
## Summary
- restore Home Assistant media-player volume projection using Trinnov dB state
- map HA `volume_level` 0..1 to the safe dB range `-120.0..0.0` and call `volume_set` with dB
- share dB bounds with the number entity so precise automations still use the raw dB number

## Root cause
The protocol volume is dB, while Home Assistant media-player volume is normalized 0..1. The previous HA projection either treated percentage as the source of truth or removed the media-player projection entirely. This keeps the protocol/library dB-only and makes Home Assistant do the edge conversion.

## Mapping
- `-120.0 dB` -> `0.0`
- `-17.5 dB` -> `0.8541666667`
- `0.0 dB` -> `1.0`

## Validation
- `.venv/bin/ruff check custom_components tests`
- `.venv/bin/ruff format --check custom_components tests`
- `.venv/bin/ty check custom_components/trinnov_altitude`
- `.venv/bin/pytest tests/test_media_player.py tests/test_number.py -v --no-cov`
- `make test`

Note: `uv run` is currently blocked in this worktree by the existing local source override for `../py-trinnov-altitude`, which is not present under this `dewy-acorn` worktree. The repo-local `.venv` checks pass.