### PR TITLE
fix: add periodic reconcile poll to coordinator (push-staleness backstop)

### DIFF
--- a/custom_components/trinnov_altitude/coordinator.py
+++ b/custom_components/trinnov_altitude/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.core import HomeAssistant
@@ -26,6 +27,13 @@ class TrinnovAltitudeCoordinator(DataUpdateCoordinator["AltitudeSnapshot"]):
     """Push coordinator for Trinnov Altitude state."""
 
     _BOOTSTRAP_RETRY_INTERVAL_SECONDS = 5.0
+    # Reconciliation backstop: the integration is push-driven, but a live control
+    # link can silently miss an individual state-change message, leaving HA stale
+    # until the next incidental push. A light periodic poll asks the device to
+    # re-report its current state so a dropped push self-corrects. Every push
+    # resets this timer (async_set_updated_data), so it effectively only fires
+    # after a quiet period -- push stays the fast path, this is only a backstop.
+    _RECONCILE_INTERVAL_SECONDS = 20.0
 
     def __init__(
         self,
@@ -35,7 +43,12 @@ class TrinnovAltitudeCoordinator(DataUpdateCoordinator["AltitudeSnapshot"]):
         stable_device_id: str,
     ) -> None:
         """Initialize coordinator."""
-        super().__init__(hass, logger=client.logger, name="trinnov_altitude")
+        super().__init__(
+            hass,
+            logger=client.logger,
+            name="trinnov_altitude",
+            update_interval=timedelta(seconds=self._RECONCILE_INTERVAL_SECONDS),
+        )
         self.client = client
         self.commands = commands
         self.stable_device_id = stable_device_id
@@ -100,7 +113,27 @@ class TrinnovAltitudeCoordinator(DataUpdateCoordinator["AltitudeSnapshot"]):
         self._running = False
 
     async def _async_update_data(self) -> AltitudeSnapshot:
-        """Return latest state snapshot."""
+        """Reconcile with the device, then return the latest snapshot.
+
+        Push remains the primary path; this periodic reconcile only asks the
+        device to re-report its current state so a silently dropped push
+        self-corrects. The responses flow back through the existing adapter
+        callback. A failed poll is non-fatal -- push and the bootstrap retry
+        still recover a genuinely dead link -- so we keep the last snapshot
+        rather than marking entities unavailable.
+        """
+        if self._running and self.client.connected:
+            try:
+                await self.client.state_get_current()
+            except (
+                ConnectionFailedError,
+                ConnectionTimeoutError,
+                TimeoutError,
+            ) as err:
+                self.client.logger.debug(
+                    "Trinnov reconcile poll failed (%s); relying on push + bootstrap retry.",
+                    err,
+                )
         return self._snapshot_state()
 
     def _snapshot_state(self) -> AltitudeSnapshot:


### PR DESCRIPTION
## Problem

`TrinnovAltitudeCoordinator` is 100% push-driven — it never sets `update_interval`, and `_async_update_data()` only re-snapshots already-cached client state. There is no polling backstop.

The v3.3.6 heartbeat fix (#38) recovers a **dead** control link, but it does nothing for a **live** link that silently drops a single state-change message. When that happens, HA's cached view (source / preset / volume) goes stale until the next incidental push arrives — which can be a long time on an idle system.

### Observed in the field

On a deployed 2.2.5 instance (library 3.3.6, healthy `connected` link, zero reconnects/reloads in 72h):

- When a Roon source started, the `select.*_source` entity lagged the device by **~20–40s** before an incidental push corrected it.
- `last_reported` on the connection/health/power/source entities froze for **tens of minutes** (observed up to ~47 min and ~2.5 h) with no reconciliation.

Any automation that *reads* Trinnov state to make a decision can act on stale data during these windows. (Write-driven paths happen to be robust because issuing a command forces a fresh push.)

## Fix

Add a light reconcile backstop that layers on top of push (push stays the fast path):

- Set `update_interval = 20s`.
- Have `_async_update_data()` ask the device to re-report its current state via `client.state_get_current()` when connected. Responses flow back through the existing adapter callback, so no new plumbing.
- Every push calls `async_set_updated_data`, which resets the `DataUpdateCoordinator` timer — so the poll effectively only fires **after a quiet period**, not during active push traffic.
- A failed poll is non-fatal: it logs at debug and keeps the last snapshot rather than marking entities unavailable (the bootstrap-retry path still handles a genuinely dead link).

Net effect: a silently dropped push self-corrects within ~20s instead of persisting indefinitely.

## Testing

- `python -m py_compile` passes; logic reviewed against the existing push/adapter callback flow.
- Motivated by the live staleness evidence above.
- **Not yet runtime-tested on hardware** — I did not want to ship a live edit to my HACS-managed deployment. Happy to adjust the interval or approach; feedback welcome on whether `state_get_current()` is the preferred reconcile primitive vs. `preset_get()`/`source_get()`.
