### PR TITLE
fix: require trinnov-altitude 3.3.9

### DIFF
--- a/custom_components/trinnov_altitude/manifest.json
+++ b/custom_components/trinnov_altitude/manifest.json
@@ -12,7 +12,7 @@
     "trinnov_altitude"
   ],
   "requirements": [
-    "trinnov-altitude>=3.3.8"
+    "trinnov-altitude>=3.3.9"
   ],
   "version": "2.2.7"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.7"
 description = "Home Assistant integration for Trinnov Altitude"
 requires-python = ">=3.11"
 dependencies = [
-    "trinnov-altitude>=3.3.8",
+    "trinnov-altitude>=3.3.9",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -8319,14 +8319,14 @@ wheels = [
 
 [[package]]
 name = "trinnov-altitude"
-version = "3.3.8"
+version = "3.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wakeonlan" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/28/e81a96445a1d95b6afb56dad4873b2249864cc92482e7d4c7cba556c9c21/trinnov_altitude-3.3.8.tar.gz", hash = "sha256:ab99310c34e1d62abe0123f220092b15eab481ba797548fe0f078ed7462896c7", size = 258806, upload-time = "2026-07-30T00:01:20.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/a8/65ff33466cc91def6efc66a6d2127f5bd8ae1f812462ccbd526c68597b76/trinnov_altitude-3.3.9.tar.gz", hash = "sha256:8f5f5a6184b97be73dc92dd68d39e147d4c503e7f0d29f565d3753a2713d71ab", size = 259289, upload-time = "2026-07-30T00:16:19.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/9f/bfd8f68d576a05efcc57e09edbcbde01e15ca041a6ad582c5659cb6fcb0a/trinnov_altitude-3.3.8-py3-none-any.whl", hash = "sha256:e7214af54fe5232ede988e88bcc19977cee33df2c8d9c383aef5bb92dda62bc7", size = 32188, upload-time = "2026-07-30T00:01:19.092Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/1d/faea9f17c9f2e65d4357577aae3179484c89fc6e1532721718d6bca23312/trinnov_altitude-3.3.9-py3-none-any.whl", hash = "sha256:a62bc82969377409105b59c858a97cfc44d9f98bb143238e74b1a10b359e6708", size = 32469, upload-time = "2026-07-30T00:16:17.862Z" },
 ]
 
 [[package]]
@@ -8362,7 +8362,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.8" }]
+requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.9" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- require `trinnov-altitude>=3.3.9` in the integration manifest and development metadata
- lock the published PyPI 3.3.9 artifacts and hashes

This picks up credential redaction for unknown protocol messages, preventing the Altitude WLAN password field from being retained or written to Home Assistant logs.

## Verification
- installed the published PyPI package with `uv sync --locked --no-sources --no-cache`
- verified the test environment imports `trinnov-altitude==3.3.9`
- `make check` (`139 passed`, 95.42% coverage)