### PR TITLE
fix: stop reporting stale on state after standby disconnect

### DIFF
--- a/custom_components/trinnov_altitude/commands.py
+++ b/custom_components/trinnov_altitude/commands.py
@@ -8,7 +8,6 @@ from homeassistant.exceptions import HomeAssistantError
 
 from trinnov_altitude.client import TrinnovAltitudeClient
 from trinnov_altitude.exceptions import NotConnectedError, TrinnovAltitudeError
-from trinnov_altitude.lifecycle import PowerState
 
 
 class TrinnovAltitudeCommands:
@@ -46,6 +45,10 @@ class TrinnovAltitudeCommands:
                 await getattr(self._client, method_name)(*args)
                 return
 
+            if method_name == "power_off":
+                await self._client.power_off(wait_for_ack=require_ack)
+                return
+
             if require_ack:
                 line = self._build_line(method_name, args)
                 if line is not None:
@@ -54,10 +57,6 @@ class TrinnovAltitudeCommands:
                         wait_for_ack=True,
                         ack_timeout=self._client.command_timeout,
                     )
-                    if method_name == "power_off":
-                        self._client.runtime = self._client.runtime.with_changes(
-                            power=PowerState.OFF
-                        )
                     return
 
             await getattr(self._client, method_name)(*args)
@@ -68,8 +67,6 @@ class TrinnovAltitudeCommands:
 
     def _build_line(self, method_name: str, args: tuple[Any, ...]) -> str | None:
         """Build raw protocol line for known methods."""
-        if method_name == "power_off":
-            return "power_off_SECURED_FHZMCH48FE"
         if method_name == "preset_set" and len(args) == 1:
             return f"loadp {int(args[0])}"
         if method_name == "source_set" and len(args) == 1:

--- a/custom_components/trinnov_altitude/coordinator.py
+++ b/custom_components/trinnov_altitude/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 from homeassistant.core import HomeAssistant
@@ -84,6 +85,8 @@ class TrinnovAltitudeCoordinator(DataUpdateCoordinator["AltitudeSnapshot"]):
 
         if self._bootstrap_retry_task is not None:
             self._bootstrap_retry_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._bootstrap_retry_task
             self._bootstrap_retry_task = None
 
         if self._callback_registered:

--- a/custom_components/trinnov_altitude/media_player.py
+++ b/custom_components/trinnov_altitude/media_player.py
@@ -123,9 +123,9 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
     def state(self) -> MediaPlayerState:
         """State of device."""
         power_status = self.coordinator.power_status
-        if power_status is PowerState.OFF:
+        if power_status in {PowerState.OFF, PowerState.UNKNOWN}:
             return MediaPlayerState.OFF
-        if power_status in {PowerState.WAKING, PowerState.UNKNOWN}:
+        if power_status is PowerState.WAKING:
             return MediaPlayerState.ON
         if self._state.source_format:
             return MediaPlayerState.PLAYING

--- a/scripts/trinnov_lifecycle_probe.py
+++ b/scripts/trinnov_lifecycle_probe.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Exercise the real py-trinnov-altitude client against a live device the same
+way the Home Assistant coordinator does, and log every runtime/power state
+transition with timestamps. Meant to reproduce the network-standby wake flow
+end-to-end (client.start() while off -> client.power_on() -> watch until
+synced) so we can see exactly where/why it diverges from a normal wake.
+
+Usage:
+    python3 trinnov_lifecycle_probe.py <ip> <mac> [max-seconds]
+
+Requires the sibling py-trinnov-altitude checkout on PYTHONPATH.
+"""
+
+import asyncio
+import sys
+import time
+
+sys.path.insert(0, "/Users/adam/Development/py-trinnov-altitude")
+
+from trinnov_altitude.client import TrinnovAltitudeClient  # noqa: E402
+from trinnov_altitude import exceptions  # noqa: E402
+
+
+async def main() -> None:
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    host = sys.argv[1]
+    mac = sys.argv[2]
+    max_seconds = float(sys.argv[3]) if len(sys.argv) > 3 else 180.0
+
+    t0 = time.monotonic()
+
+    def ts() -> str:
+        return f"+{time.monotonic() - t0:6.2f}s"
+
+    def log(msg: str) -> None:
+        print(f"[{ts()}] {msg}")
+
+    last_runtime = None
+
+    def on_event(event: str, message: object) -> None:
+        nonlocal last_runtime
+        if event == "received_message":
+            return
+        log(f"EVENT: {event}")
+
+    client = TrinnovAltitudeClient(host=host, mac=mac, reconnect_max_backoff=10.0)
+    client.register_callback(on_event)
+
+    log("Calling client.start() (expect this to fail since device is off)...")
+    try:
+        await client.start()
+        log("client.start() succeeded immediately (device was already reachable).")
+    except (exceptions.ConnectionFailedError, exceptions.ConnectionTimeoutError) as err:
+        log(f"client.start() raised as expected: {type(err).__name__}: {err}")
+        log("Scheduling background retry loop (mirrors coordinator._schedule_bootstrap_retry)...")
+
+        async def retry_until_synced() -> None:
+            while not client.state.synced:
+                try:
+                    await client.start()
+                    await client.wait_synced(timeout=5.0)
+                    if client.state.synced:
+                        return
+                except (exceptions.ConnectionFailedError, exceptions.ConnectionTimeoutError, asyncio.TimeoutError):
+                    pass
+                await asyncio.sleep(5.0)
+
+        retry_task = asyncio.create_task(retry_until_synced())
+
+        log("Calling client.power_on() (sends WOL magic packet)...")
+        client.power_on()
+        log(f"runtime.power = {client.runtime.power}")
+
+        deadline = time.monotonic() + max_seconds
+        last_power = None
+        last_transport = None
+        last_sync = None
+        while time.monotonic() < deadline:
+            if (
+                client.runtime.power != last_power
+                or client.runtime.transport != last_transport
+                or client.runtime.sync != last_sync
+            ):
+                log(
+                    f"runtime: power={client.runtime.power} transport={client.runtime.transport} "
+                    f"sync={client.runtime.sync} control={client.runtime.control} "
+                    f"state.synced={client.state.synced}"
+                )
+                last_power, last_transport, last_sync = (
+                    client.runtime.power,
+                    client.runtime.transport,
+                    client.runtime.sync,
+                )
+            if client.state.synced:
+                log("SYNCED. Success.")
+                break
+            await asyncio.sleep(0.5)
+        else:
+            log(f"TIMED OUT after {max_seconds}s without becoming synced.")
+
+        retry_task.cancel()
+
+    await client.stop()
+    log("Stopped.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/trinnov_probe.py
+++ b/scripts/trinnov_probe.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Standalone Trinnov Altitude control-port probe (no dependencies).
+
+Connects to the Altitude's control TCP port (default 44100) and logs, with
+timestamps, exactly what happens: whether the connect succeeds/fails/times
+out, and whatever raw lines the device sends after we say "id" and ask for
+"get_current_state". Run this once with the device fully ON, and once with
+it in the new network-standby mode, and compare the two logs.
+
+Usage:
+    python3 trinnov_probe.py <altitude-ip> [port]
+
+Ctrl+C to stop. It will keep listening for up to 15s after sending commands
+so we can see if anything trickles in late.
+"""
+
+import socket
+import sys
+import time
+
+
+def ts() -> str:
+    return time.strftime("%H:%M:%S")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    host = sys.argv[1]
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 44100
+
+    print(f"[{ts()}] Connecting to {host}:{port} (connect timeout 5s)...")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(5.0)
+    start = time.monotonic()
+    try:
+        sock.connect((host, port))
+    except Exception as err:
+        print(f"[{ts()}] CONNECT FAILED after {time.monotonic() - start:.2f}s: {type(err).__name__}: {err}")
+        return
+    print(f"[{ts()}] CONNECT OK after {time.monotonic() - start:.2f}s")
+
+    sock.settimeout(3.0)
+
+    def read_for(seconds: float) -> None:
+        deadline = time.monotonic() + seconds
+        buf = b""
+        while time.monotonic() < deadline:
+            remaining = max(0.1, deadline - time.monotonic())
+            sock.settimeout(min(3.0, remaining))
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                continue
+            except Exception as err:
+                print(f"[{ts()}] READ ERROR: {type(err).__name__}: {err}")
+                return
+            if chunk == b"":
+                print(f"[{ts()}] PEER CLOSED CONNECTION")
+                return
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                print(f"[{ts()}] RECV: {line!r}")
+
+    print(f"[{ts()}] Listening for any unsolicited data for 5s before sending anything...")
+    read_for(5.0)
+
+    for cmd in ["id trinnov_probe", "get_current_state", "upmixer"]:
+        try:
+            print(f"[{ts()}] SEND: {cmd!r}")
+            sock.sendall((cmd + "\n").encode("ascii"))
+        except Exception as err:
+            print(f"[{ts()}] SEND FAILED: {type(err).__name__}: {err}")
+            return
+        read_for(3.0)
+
+    print(f"[{ts()}] Final listen window (10s)...")
+    read_for(10.0)
+
+    sock.close()
+    print(f"[{ts()}] Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trinnov_wake_probe.py
+++ b/scripts/trinnov_wake_probe.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Send a Wake-on-LAN magic packet, then poll the Trinnov control port until
+it accepts a connection, and log the full handshake with timestamps relative
+to the WOL send. This is meant to compare a "fast boot" wake (from the new
+network-standby mode) against a normal cold boot.
+
+Usage:
+    python3 trinnov_wake_probe.py <altitude-ip> <mac-address> [port]
+"""
+
+import re
+import socket
+import struct
+import sys
+import time
+
+
+def send_magic_packet(mac: str, broadcast: str = "255.255.255.255", port: int = 9) -> None:
+    mac_bytes = bytes.fromhex(re.sub(r"[:-]", "", mac))
+    packet = b"\xff" * 6 + mac_bytes * 16
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    sock.sendto(packet, (broadcast, port))
+    sock.close()
+
+
+def ts(t0: float) -> str:
+    return f"+{time.monotonic() - t0:6.2f}s"
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    host = sys.argv[1]
+    mac = sys.argv[2]
+    port = int(sys.argv[3]) if len(sys.argv) > 3 else 44100
+
+    t0 = time.monotonic()
+    print(f"[{ts(t0)}] Sending WOL magic packet to {mac}...")
+    send_magic_packet(mac)
+
+    print(f"[{ts(t0)}] Polling {host}:{port} every 0.25s until it accepts a connection (giving up after 60s)...")
+    sock: socket.socket | None = None
+    deadline = time.monotonic() + 60
+    attempts = 0
+    while time.monotonic() < deadline:
+        attempts += 1
+        candidate = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        candidate.settimeout(0.5)
+        try:
+            candidate.connect((host, port))
+            sock = candidate
+            break
+        except Exception:
+            candidate.close()
+            time.sleep(0.25)
+
+    if sock is None:
+        print(f"[{ts(t0)}] Gave up after {attempts} attempts; never connected.")
+        return
+
+    print(f"[{ts(t0)}] CONNECTED after {attempts} attempts.")
+    sock.settimeout(2.0)
+
+    def read_for(seconds: float) -> None:
+        deadline_inner = time.monotonic() + seconds
+        buf = b""
+        while time.monotonic() < deadline_inner:
+            remaining = max(0.1, deadline_inner - time.monotonic())
+            sock.settimeout(min(2.0, remaining))
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                continue
+            except Exception as err:
+                print(f"[{ts(t0)}] READ ERROR: {type(err).__name__}: {err}")
+                return
+            if chunk == b"":
+                print(f"[{ts(t0)}] PEER CLOSED CONNECTION")
+                return
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                print(f"[{ts(t0)}] RECV: {line!r}")
+
+    read_for(3.0)
+
+    for cmd in ["id trinnov_probe", "get_current_state", "upmixer"]:
+        try:
+            print(f"[{ts(t0)}] SEND: {cmd!r}")
+            sock.sendall((cmd + "\n").encode("ascii"))
+        except Exception as err:
+            print(f"[{ts(t0)}] SEND FAILED: {type(err).__name__}: {err}")
+            return
+        read_for(3.0)
+
+    print(f"[{ts(t0)}] Final listen window (10s)...")
+    read_for(10.0)
+
+    sock.close()
+    print(f"[{ts(t0)}] Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,11 @@ def mock_trinnov_device():
 
     # Commands
     device.power_on = MagicMock()
-    device.power_off = AsyncMock()
+
+    async def _power_off(wait_for_ack: bool = False) -> None:
+        device.runtime = device.runtime.with_changes(power=PowerState.OFF)
+
+    device.power_off = AsyncMock(side_effect=_power_off)
     device.power_on_available = MagicMock(return_value=True)
 
     device.volume_set = AsyncMock()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -15,6 +15,7 @@ def _mock_client() -> MagicMock:
     client.command_timeout = 2.0
     client.command = AsyncMock()
     client.mute_on = AsyncMock()
+    client.power_off = AsyncMock()
     client.preset_set = AsyncMock()
     client.source_set = AsyncMock()
     client.source_set_by_name = AsyncMock()
@@ -24,15 +25,15 @@ def _mock_client() -> MagicMock:
 
 
 async def test_invoke_with_ack_for_power_off() -> None:
-    """Power off should use raw command + ACK flow when required."""
+    """Power off should delegate to the client's own power_off, which owns the
+    runtime state transition so listeners are notified via _set_runtime."""
     client = _mock_client()
     commands = TrinnovAltitudeCommands(client)
 
     await commands.invoke("power_off", require_ack=True)
 
-    client.command.assert_called_once_with(
-        "power_off_SECURED_FHZMCH48FE", wait_for_ack=True, ack_timeout=2.0
-    )
+    client.power_off.assert_called_once_with(wait_for_ack=True)
+    client.command.assert_not_called()
 
 
 async def test_invoke_with_ack_for_preset_set() -> None:

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -68,7 +68,10 @@ async def test_media_player_off_state(
     mock_trinnov_device_offline,
     mock_setup_entry,
 ):
-    """Test media player does not claim off from disconnected transport alone."""
+    """Test media player reports off, not a stale on, once the device is
+    disconnected with an unknown power state (e.g. it dropped into standby
+    on its own). Per AGENTS.md's lifecycle contract, media_player should be
+    off when powered down as long as HA can still turn it on."""
     mock_setup_entry.return_value = mock_trinnov_device_offline
 
     mock_config_entry.add_to_hass(hass)
@@ -78,7 +81,7 @@ async def test_media_player_off_state(
 
     state = hass.states.get("media_player.trinnov_altitude_192_168_1_100")
     assert state
-    assert state.state == MediaPlayerState.ON
+    assert state.state == MediaPlayerState.OFF
 
 
 async def test_media_player_booting_state(
@@ -210,9 +213,7 @@ async def test_media_player_turn_off(
         blocking=True,
     )
 
-    mock_device.command.assert_called_once_with(
-        "power_off_SECURED_FHZMCH48FE", wait_for_ack=True, ack_timeout=2.0
-    )
+    mock_device.power_off.assert_called_once_with(wait_for_ack=True)
 
     state = hass.states.get("media_player.trinnov_altitude_192_168_1_100")
     assert state
@@ -391,5 +392,7 @@ async def test_media_player_available_when_offline_with_mac(
 
     state = hass.states.get("media_player.trinnov_altitude_192_168_1_100")
     assert state
-    # Should be available even when offline because power_on_available returns True
-    assert state.state == MediaPlayerState.ON
+    # Available (not "unavailable") because power_on_available returns True, but
+    # still reports off since the device is actually disconnected.
+    assert state.state != "unavailable"
+    assert state.state == MediaPlayerState.OFF

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -117,9 +117,7 @@ async def test_remote_turn_off(
         blocking=True,
     )
 
-    mock_device.command.assert_called_once_with(
-        "power_off_SECURED_FHZMCH48FE", wait_for_ack=True, ack_timeout=2.0
-    )
+    mock_device.power_off.assert_called_once_with(wait_for_ack=True)
 
 
 async def test_remote_send_command_simple(


### PR DESCRIPTION
## Summary

Fixes #78 — the Altitude CI's new network-standby mode.

Root cause was actually two-layered:

1. **Library-level (binarylogic/py-trinnov-altitude#47, needs to merge/release first):** a connection reset during the reconnect handshake killed the client's listen task outright instead of retrying, leaving the integration permanently stuck reporting stale state after the device dropped into standby — recoverable only with a full Home Assistant restart.
2. **This repo:** even once the library reconnects correctly, `media_player`'s `state` property mapped `PowerState.UNKNOWN` (the ambiguous state after any unexpected disconnect) to `MediaPlayerState.ON`. So the entity got stuck showing "on" indefinitely after a standby disconnect, while the `remote` entity correctly showed off — exactly the split shown in the issue.

Both were reproduced and the fixes verified end-to-end against a real Altitude CI cycling through its network-standby mode.

## Changes

- `media_player.py`: `PowerState.UNKNOWN` now maps to `MediaPlayerState.OFF` instead of `ON`, matching the lifecycle contract already documented in `AGENTS.md` ("media_player: off when powered down if HA can still turn the device on").
- `commands.py`: `power_off` now delegates to the client's own `power_off()` (which now supports `wait_for_ack`) instead of hand-building the raw protocol line and mutating `client.runtime` directly — that direct mutation bypassed `_set_runtime()`'s listener notification, which could leave entities out of sync with the actual commanded-off state.
- `coordinator.py`: await the cancelled bootstrap-retry task on shutdown instead of firing-and-forgetting the cancellation, consistent with how the client already handles its own tasks. Also fixes a "Reload" failure that could force a full HA restart to recover.
- `scripts/`: standalone diagnostic scripts used to reproduce this against real hardware, kept for future standby/wake debugging.

## Blocked on

This depends on binarylogic/py-trinnov-altitude#47 merging and being released, then this repo's `manifest.json`/`pyproject.toml` minimum version needs bumping to that release before merging. Opening as a draft for that reason.

## Test plan

- [x] `uv run pytest` — 139 passed
- [x] `uv run ruff check custom_components tests` — clean
- [x] Verified end-to-end against a real Altitude CI: standby → wake via `remote.turn_on`/`media_player.turn_on`, and `remote.turn_off`/`media_player.turn_off` round trips, confirming entities recover on their own without a manual Reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)