### PR TITLE
fix: require trinnov-altitude 3.3.10

### DIFF
--- a/custom_components/trinnov_altitude/manifest.json
+++ b/custom_components/trinnov_altitude/manifest.json
@@ -12,7 +12,7 @@
     "trinnov_altitude"
   ],
   "requirements": [
-    "trinnov-altitude>=3.3.9"
+    "trinnov-altitude>=3.3.10"
   ],
   "version": "2.2.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.7"
 description = "Home Assistant integration for Trinnov Altitude"
 requires-python = ">=3.11"
 dependencies = [
-    "trinnov-altitude>=3.3.9",
+    "trinnov-altitude>=3.3.10",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -8319,14 +8319,14 @@ wheels = [
 
 [[package]]
 name = "trinnov-altitude"
-version = "3.3.9"
+version = "3.3.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wakeonlan" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/a8/65ff33466cc91def6efc66a6d2127f5bd8ae1f812462ccbd526c68597b76/trinnov_altitude-3.3.9.tar.gz", hash = "sha256:8f5f5a6184b97be73dc92dd68d39e147d4c503e7f0d29f565d3753a2713d71ab", size = 259289, upload-time = "2026-07-30T00:16:19.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/3a/7162a64168a7dfe070b27e88de9ce4ee86f43444f17e3a6523310c9950a1/trinnov_altitude-3.3.10.tar.gz", hash = "sha256:91182821baf2b2490f56ccf3b5c1c418ac31c53e5f8a041555a91d778243fc6f", size = 259824, upload-time = "2026-08-16T23:13:10.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/1d/faea9f17c9f2e65d4357577aae3179484c89fc6e1532721718d6bca23312/trinnov_altitude-3.3.9-py3-none-any.whl", hash = "sha256:a62bc82969377409105b59c858a97cfc44d9f98bb143238e74b1a10b359e6708", size = 32469, upload-time = "2026-07-30T00:16:17.862Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b3/605f6528924cb3c2e688bed1807e5d9a48f40fe8b3f37b59df13f7c351e5/trinnov_altitude-3.3.10-py3-none-any.whl", hash = "sha256:53d7be43c5e518a8acd645da7cd52e83f8f1b6a6a75d493042c0f12025c5b6f1", size = 32504, upload-time = "2026-08-16T23:13:09.282Z" },
 ]
 
 [[package]]
@@ -8362,7 +8362,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.9" }]
+requires-dist = [{ name = "trinnov-altitude", specifier = ">=3.3.10" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- require py-trinnov-altitude 3.3.10 for transactional bootstrap reconnects
- update the registry-resolved lockfile

## Validation
- `make check`
- 139 tests passed
- installed distribution verified as `trinnov-altitude==3.3.10` from PyPI

This intentionally does not change Home Assistant entity semantics.